### PR TITLE
Issue #119

### DIFF
--- a/src/main/java/com/github/jreddit/action/SubmitActions.java
+++ b/src/main/java/com/github/jreddit/action/SubmitActions.java
@@ -80,8 +80,8 @@ public class SubmitActions implements ActorDriven {
             return false;
         } 
         else if(object.toJSONString().contains(".error.RATELIMIT.field-ratelimit")){
-        	System.err.println("User submission failed: You need to wait before posting again");
-        	return false;
+            System.err.println("User submission failed: You need to wait before posting again");
+            return false;
         } else {
             return true;
         }

--- a/src/main/java/com/github/jreddit/action/SubmitActions.java
+++ b/src/main/java/com/github/jreddit/action/SubmitActions.java
@@ -78,6 +78,10 @@ public class SubmitActions implements ActorDriven {
         if (object.toJSONString().contains(".error.USER_REQUIRED")) {
             System.err.println("User submission failed: please login first.");
             return false;
+        } 
+        else if(object.toJSONString().contains(".error.RATELIMIT.field-ratelimit")){
+        	System.err.println("User submission failed: You need to wait before posting again");
+        	return false;
         } else {
             return true;
         }

--- a/src/test/java/com/github/jreddit/action/SubmitActionsTest.java
+++ b/src/test/java/com/github/jreddit/action/SubmitActionsTest.java
@@ -118,7 +118,7 @@ public class SubmitActionsTest {
 
         // Attempt to comment
         boolean res = submitAction.comment("fullname", "text");
-        assertEquals(errorOutput.toString().contains("User submission failed: please login first."), true);
+        assertTrue(errorOutput.toString().contains("User submission failed: please login first."));
         assertFalse(res);
     }
     
@@ -140,7 +140,7 @@ public class SubmitActionsTest {
 
         // Attempt to comment
         boolean res = submitAction.comment("fullname", "text");
-        assertEquals(errorOutput.toString().contains("User submission failed: You need to wait before posting again"), true);
+        assertTrue(errorOutput.toString().contains("User submission failed: You need to wait before posting again"));
         assertFalse(res);
     }
 


### PR DESCRIPTION
So, new Reddit users can't comment too fast. There's a limit of 10 minutes for certain subreddits.
The comment() method returned true even tho it was not effectively posting.
I described the problem here #119 .

This pull requests aims to fix the issue. 

There are two commits because I had to fix the indentation in the second one.